### PR TITLE
+ Refactor botany CSS styles and templates

### DIFF
--- a/backend/botany/static/botany/botany.css
+++ b/backend/botany/static/botany/botany.css
@@ -1,0 +1,218 @@
+.paragraph-top.blog-post {
+  max-width: 36em;
+  margin-bottom: .5em;
+}
+
+.collection-list-posts {
+  grid-column-gap: 1.5em;
+  grid-row-gap: 3.4em;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.collection-list-posts.large {
+  grid-template-columns: 1fr;
+}
+
+.block-post {
+  background-color: var(--white);
+  border-radius: .87em;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  display: flex;
+  box-shadow: 0 15px 25px -10px rgba(20, 23, 24, .05);
+}
+
+.block-post.large {
+  grid-column-gap: 0em;
+  grid-row-gap: 0em;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-columns: 1fr;
+  display: grid;
+}
+
+.collection-list-wrapper-posts.large {
+  margin-bottom: 3.4em;
+}
+
+.image-post-thumbnail {
+  width: 100%;
+  height: 15em;
+  object-fit: cover;
+  border-radius: .87em;
+}
+
+.image-post-thumbnail.large {
+  height: auto;
+  max-height: 40em;
+}
+
+.link-post-thumbnail {
+  width: 100%;
+}
+
+.link-post-thumbnail.large {
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: stretch;
+  display: flex;
+}
+
+.post {
+  width: 100%;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding: 2.5em 2.8em;
+  display: flex;
+}
+
+.post.large {
+  justify-content: center;
+  padding: 4.3em 4.5em;
+}
+
+.link-heading-post {
+  margin-bottom: 1.3em;
+  text-decoration: none;
+}
+
+.link-heading-post.large {
+  margin-bottom: 1.4em;
+}
+
+.date {
+  color: rgba(20, 23, 24, .5);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  margin-bottom: .8em;
+  font-family: IBM Plex Mono, sans-serif;
+  font-size: .7em;
+  font-weight: 500;
+  line-height: 130%;
+}
+
+.paragraph-post {
+  margin-bottom: 1.4em;
+}
+
+.paragraph-post.large {
+  max-width: 25em;
+  margin-bottom: 1.6em;
+}
+
+.empty-state {
+  background-color: var(--white);
+  text-align: center;
+  border-radius: .87em;
+  padding: 1em 1.4em;
+  box-shadow: 0 15px 25px -10px rgba(20, 23, 24, .05);
+}
+
+.text-empty {
+  opacity: .7;
+  color: var(--heading);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  font-family: IBM Plex Mono, sans-serif;
+  font-size: .7em;
+  font-weight: 500;
+  line-height: 130%;
+}
+
+.date-top {
+  color: rgba(20, 23, 24, .5);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  margin-bottom: .8em;
+  font-family: IBM Plex Mono, sans-serif;
+  font-size: .7em;
+  font-weight: 500;
+  line-height: 130%;
+}
+
+.post-body {
+  width: 100%;
+  background-color: var(--white);
+  border-radius: .87em;
+  padding: 4em 13%;
+  box-shadow: 0 15px 25px -10px rgba(20, 23, 24, .05);
+}
+
+.image-main-post {
+  width: 100%;
+  object-fit: cover;
+  border-radius: .87em;
+}
+
+@media screen and (max-width: 991px) {
+  .collection-list-posts {
+    grid-column-gap: 1.13em;
+    grid-row-gap: 3em;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .collection-list-wrapper-posts.large {
+    margin-bottom: 3em;
+  }
+
+  .image-post-thumbnail {
+    height: 28vw;
+  }
+
+  .post.large {
+    padding: 3.4em 3.2em;
+  }
+
+  .post-body {
+    padding-left: 10%;
+    padding-right: 10%;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .collection-list-posts {
+    grid-row-gap: 2em;
+    grid-template-columns: 1fr;
+  }
+
+  .block-post.large {
+    grid-template-columns: 1fr;
+  }
+
+  .collection-list-wrapper-posts.large {
+    margin-bottom: 2em;
+  }
+
+  .image-post-thumbnail, .image-post-thumbnail.large {
+    height: 50vw;
+  }
+
+  .post-body {
+    padding-top: 2.9em;
+    padding-bottom: 2.9em;
+  }
+}
+
+@media screen and (max-width: 479px) {
+  .collection-list-posts {
+    grid-row-gap: 1.5em;
+  }
+
+  .collection-list-wrapper-posts.large {
+    margin-bottom: 1.5em;
+  }
+
+  .post, .post.large {
+    padding: 1.8em 2.2em;
+  }
+
+  .post-body {
+    padding-top: 2.5em;
+    padding-bottom: 2.5em;
+  }
+}

--- a/backend/botany/templates/botany/base.html
+++ b/backend/botany/templates/botany/base.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block extra_css %}
-  <link rel="stylesheet" type="text/css" href="{% static 'blog/blog.css' %}">
+  <link rel="stylesheet" type="text/css" href="{% static 'botany/botany.css' %}">
 {% endblock  %}
 
 {% block body %}

--- a/backend/botany/templates/botany/inventory_box.html
+++ b/backend/botany/templates/botany/inventory_box.html
@@ -1,12 +1,12 @@
 {% extends "botany/base.html" %}
-{% load static wagtailcore_tags wagtailimages_tags %}
+{% load static %}
 
 {% block content %}
   <section class="section-top">
     <div class="content">
       <div class="block-top">
-        <h1 class="heading-top">{{ page.title }}</h1>
-        <p class="paragraph-top">{{ page.intro|richtext }}</p>
+        <h1 class="heading-top"></h1>
+        <p class="paragraph-top"></p>
       </div>
     </div>
   </section>
@@ -17,13 +17,7 @@
           <div role="listitem" class="w-dyn-item">
             <div class="block-post large">
               <a href="#" class="link-post-thumbnail large w-inline-block">
-                {% with post.main_image as main_image %}
-                  {% if main_image %}
-                    {% image main_image original class="image-post-thumbnail large" %}
-                  {% else %}
-                    <img alt="Featured plant thumbnail placeholder" loading="lazy" decoding="async" src="{% static 'botany/plant-placeholder.svg' %}" class="image-post-thumbnail">
-                  {% endif %}
-                {% endwith %}
+                <img alt="Featured plant thumbnail placeholder" loading="lazy" decoding="async" src="{% static 'botany/plant-placeholder.svg' %}" class="image-post-thumbnail">
               </a>
               <div class="post large">
                 <div class="date"></div>
@@ -43,42 +37,31 @@
         </div>
       </div>
       <div class="collection-list-wrapper-posts w-dyn-list">
-        {% for post in page.get_children %}
-          {% with post=post.specific %}
-            <div role="list" class="collection-list-posts w-dyn-items">
-              <div role="listitem" class="w-dyn-item">
-                <div class="block-post">
-                  <a href="{% pageurl post %}" class="link-post-thumbnail w-inline-block">
-                    {% with post.main_image as main_image %}
-                      {% if main_image %}
-                        {% image main_image original class="image-post-thumbnail" %}
-                      {% else %}
-                        <img alt="Plant Thumbnail Placeholder" loading="eager" decoding="async" src="{% static 'botany/plant-placeholder.svg' %}" class="image-post-thumbnail">
-                      {% endif %}
-                    {% endwith %}
-                  </a>
-                  <div class="post">
-                    <div class="date">{{ post.date }}</div>
-                    <a href="{% pageurl post %}" class="link-heading-post w-inline-block">
-                      <h4 class="heading-post">{{ post.title }}</h4>
-                    </a>
-                    <p class="paragraph-post">{{ post.body|richtext }}</p>
-                    <a href="{% pageurl post %}" class="link-block w-inline-block">
-                      <div class="text-link">Read more</div>
-                      <div class="block-icon-link">
-                        <img src="{% static 'base/images/bx-arrow-to-right_green.svg' %}" loading="lazy" decoding="async" alt="Green Arrow Pointing Right" class="icon-link">
-                      </div>
-                    </a>
+        <div role="list" class="collection-list-posts w-dyn-items">
+          <div role="listitem" class="w-dyn-item">
+            <div class="block-post">
+              <a href="#" class="link-post-thumbnail w-inline-block">
+                <img alt="Plant Thumbnail Placeholder" loading="eager" decoding="async" src="{% static 'botany/plant-placeholder.svg' %}" class="image-post-thumbnail">
+              </a>
+              <div class="post">
+                <div class="date"></div>
+                <a href="#" class="link-heading-post w-inline-block">
+                  <h4 class="heading-post"></h4>
+                </a>
+                <p class="paragraph-post"></p>
+                <a href="#" class="link-block w-inline-block">
+                  <div class="text-link">Read more</div>
+                  <div class="block-icon-link">
+                    <img src="{% static 'base/images/bx-arrow-to-right_green.svg' %}" loading="lazy" decoding="async" alt="Green Arrow Pointing Right" class="icon-link">
                   </div>
-                </div>
+                </a>
               </div>
             </div>
-          {% endwith %}
-        {% empty %}
-          <div class="empty-state w-dyn-empty">
-            <div class="text-empty">No items found.</div>
           </div>
-        {% endfor %}
+        </div>
+        <div class="empty-state w-dyn-empty">
+          <div class="text-empty">No items found.</div>
+        </div>
       </div>
     </div>
   </section>

--- a/backend/botany/templates/botany/previews/plant.html
+++ b/backend/botany/templates/botany/previews/plant.html
@@ -1,43 +1,24 @@
 {% extends "botany/base.html" %}
-{% load wagtailcore_tags %}
+{% load static %}
 
 {% block content %}
   <section class="section-top padding-0">
     <div class="content">
       <div class="block-top">
-        <div class="date-top">{{ page.date }}</div>
-        <h1 class="heading-top">{{ page.title }}</h1>
-        <p class="paragraph-top blog-post">{{ page.intro }}</p>
+        <div class="date-top"></div>
+        <h1 class="heading-top"></h1>
+        <p class="paragraph-top blog-post"></p>
       </div>
     </div>
   </section>
   <section class="section">
     <div class="content narrow">
-      {% for item in page.gallery_images.all %}
-        <div>
-          {% image item.image original class="image-main-post" %}
-          <p>{{ item.caption }}</p>
-        </div>
-      {% empty %}
-        <img alt="Blog Post Placeholder" loading="eager" decoding="async" src="{% static 'blog/image-placeholder.svg' %}" class="image-main-post">
-      {% endfor %}
+      <img alt="Blog Post Placeholder" loading="eager" decoding="async" src="{% static 'botany/plant-placeholder.svg' %}" class="image-main-post">
       <div class="post-body">
-        <div class="rich-text-block w-dyn-bind-empty w-richtext">{{ page.body|richtext }}</div>
+        <div class="rich-text-block w-dyn-bind-empty w-richtext"></div>
       </div>
     </div>
     <p>
-      <a href="{{ page.get_parent.url }}">Return to blog</a>
+      <a href="#">Return to ...</a>
     </p>
-    {% with tags=page.tags.all %}
-      {% if tags %}
-        <div class="tags">
-          <h3>Tags</h3>
-          {% for tag in tags %}
-            <a href="{% slugurl 'tags' %}?tag={{ tag }}">
-              <button type="button">{{ tag }}</button>
-            </a>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
 {% endblock content %}

--- a/backend/botany/wagtail_hooks.py
+++ b/backend/botany/wagtail_hooks.py
@@ -28,10 +28,9 @@ class BoxModelViewSet(PageListingViewSet):
     add_to_admin_menu=True
 
 
-inventory_boxes_listing_viewset = BoxModelViewSet("inventory_boxes")
 @hooks.register("register_admin_viewset")
 def register_inventory_box_listing_viewset():
-    return inventory_boxes_listing_viewset
+    return BoxModelViewSet('inventory')
 
 
 class PlantSnippetViewSet(SnippetViewSet):
@@ -43,10 +42,11 @@ class PlantSnippetViewSet(SnippetViewSet):
     menu_label = "Plants"
     menu_name = "plants"
     menu_order = 120
-    list_per_page = 50
     copy_view_enabled = False
-    inspect_view_enabled = True
     admin_url_namespace = "inventory_plants"
+    list_display = ["name", "description"]
+    list_per_page = 50
+    admin_url_namespace = "plants"
     base_url_path = "inventory/plants"
     add_to_admin_menu=True
 


### PR DESCRIPTION
This pull request refactors the CSS styles and templates for the botany section of the website. It updates the styles for various elements such as headings, paragraphs, images, and links. The changes also include adjustments for different screen sizes using media queries. Additionally, the pull request includes updates to the templates to remove specific page titles and intros, replacing them with empty placeholders.