### PR TITLE
Refactor CI/CD workflows for Flake8 and Bandit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ jobs:
 
       - name: Check for Formatting with Flake8
         run: |
-          flake8 backend/.
+          flake8 backend/
 
       - name: Check for Security Issues with Bandit
         run: |
-          bandit -r backend/.
+          bandit -r backend/
 
       - name: Test with Pytest
         run: |
-          pytest backend/.
+          pytest backend/


### PR DESCRIPTION
This pull request refactors the CI/CD workflows for Flake8 and Bandit checks. The Flake8 check has been updated to run on the `backend/` directory instead of `backend/.`, and the Bandit check has also been updated to run on the `backend/` directory instead of `backend/.`. Additionally, the Pytest test has been updated to run on the `backend/` directory instead of `backend/.`.