### PR TITLE
Rename template used in plant_details method of InventoryBoxPage

### DIFF
--- a/backend/inventory/models.py
+++ b/backend/inventory/models.py
@@ -260,7 +260,7 @@ class InventoryBoxPage(RoutablePageMixin, Page):
         return self.render(
             request,
             context_overrides={'plant': plant},
-            template="inventory/inventory_index_page.html"
+            template="inventory/inventory_detail_page.html"
         )
 
     def get_context(self, request, *args, **kwargs):


### PR DESCRIPTION
The template used in the `plant_details` method of the `InventoryBoxPage` has been renamed from `inventory/inventory_index_page.html` to `inventory/inventory_detail_page.html`. This pull request includes the necessary file changes to reflect this renaming.