### PR TITLE
Refactor UserPlantViewSet and UserPlantSnippetViewSet to use 'user' instead of 'box__owner'

### DIFF
--- a/backend/botany/viewsets.py
+++ b/backend/botany/viewsets.py
@@ -16,4 +16,4 @@ class UserPlantViewSet(viewsets.ModelViewSet):
     authentication_classes = [JWTAuthentication]
 
     def get_queryset(self):
-        return UserPlant.objects.filter(box__owner=self.request.user)
+        return UserPlant.objects.filter(user=self.request.user)

--- a/backend/botany/wagtail_hooks.py
+++ b/backend/botany/wagtail_hooks.py
@@ -54,7 +54,7 @@ class UserPlantSnippetViewSet(SnippetViewSet):
     )
 
     def get_queryset(self, request):
-        queryset = UserPlant.objects.filter(box__owner=request.user)
+        queryset = UserPlant.objects.filter(user=request.user)
         return queryset
 
 


### PR DESCRIPTION
This pull request refactors the `UserPlantViewSet` and `UserPlantSnippetViewSet` to use the `user` field instead of the `box__owner` field. This change ensures consistency and improves readability in the codebase.