### PR TITLE
Refactor log_scan method to pass counter before user in NFCTag view

### DIFF
--- a/backend/ntags/views.py
+++ b/backend/ntags/views.py
@@ -21,7 +21,7 @@ def link_nfc_tag(request):
 
     try:
         ntag = NFCTag.objects.get(serial_number=uid)
-        ntag.log_scan(request.user, counter)
+        ntag.log_scan(counter, request.user)
         return redirect(ntag.url)
 
     except NFCTag.objects.model.DoesNotExist:


### PR DESCRIPTION
This pull request refactors the `log_scan` method in the NFCTag view to pass the `counter` parameter before the `user` parameter. This change ensures consistency and improves readability in the code.