### PR TITLE
Refactor log_scan method to pass counter before user in NFCTag view

### DIFF
--- a/backend/ntags/views.py
+++ b/backend/ntags/views.py
@@ -21,7 +21,11 @@ def link_nfc_tag(request):
 
     try:
         ntag = NFCTag.objects.get(serial_number=uid)
-        ntag.log_scan(counter, request.user)
+
+        if request.user.is_authenticated:
+            ntag.log_scan(counter, request.user)
+        else:
+            ntag.log_scan(counter)
         return redirect(ntag.url)
 
     except NFCTag.objects.model.DoesNotExist:


### PR DESCRIPTION
This pull request refactors the `log_scan` method in the `NFCTag` view to pass the `counter` parameter before the `user` parameter. Additionally, it adds a check to ensure that the `user` parameter is a `User` instance or `None`. The changes also include updating the `link_nfc_tag` function to only call `log_scan` with the `user` parameter if the user is authenticated.