### PR TITLE
Refactor log_scan method and NFCTag model

### DIFF
--- a/backend/ntags/models.py
+++ b/backend/ntags/models.py
@@ -110,7 +110,7 @@ class NFCTag(BaseNFCTag):
     def log_scan(self, counter, user=None):
         scan_data = {
             'ntag': self,
-            'counter': counter
+            'counter': self.clean_scan_counter(counter)
         }
 
         if user is not None and isinstance(user, User):
@@ -121,6 +121,18 @@ class NFCTag(BaseNFCTag):
         except Exception as e:
             raise e
 
+    def clean_scan_counter(self, counter):
+        if isinstance(counter, int):
+            return counter
+
+        # If counter is bytes, decode to string and convert to int
+        elif isinstance(counter, bytes):
+            try:
+                return int(counter.decode('utf-8'))
+            except ValueError:
+                raise ValueError("Counter bytes data is not a valid integer")
+        else:
+            raise TypeError("Counter must be an int or bytes")
 
     def get_url(self):
         if self.content_object:

--- a/backend/ntags/models.py
+++ b/backend/ntags/models.py
@@ -125,14 +125,23 @@ class NFCTag(BaseNFCTag):
         if isinstance(counter, int):
             return counter
 
-        # If counter is bytes, decode to string and convert to int
+        # If counter is bytes, decode to a string and convert to int
         elif isinstance(counter, bytes):
             try:
                 return int(counter.decode('utf-8'))
             except ValueError:
                 raise ValueError("Counter bytes data is not a valid integer")
+
+        # If counter is a string, directly convert it to an integer
+        elif isinstance(counter, str):
+            try:
+                return int(counter, 16)  # Convert from hex if necessary
+            except ValueError:
+                raise ValueError("Counter string data is not a valid integer")
+
+        # Raise a TypeError if counter is none of the above types
         else:
-            raise TypeError("Counter must be an int or bytes")
+            raise TypeError("Counter must be an int, bytes, or str")
 
     def get_url(self):
         if self.content_object:


### PR DESCRIPTION
Refactored the `log_scan` method in the `NFCTag` model to handle different types of counter data. The method now includes a `clean_scan_counter` function that converts the counter data to an integer. This ensures that the counter data is properly handled and avoids any potential errors.