### PR TITLE
Refactor permissions for trainers in assign_trainer_permissions function

### DIFF
--- a/backend/accounts/utils.py
+++ b/backend/accounts/utils.py
@@ -29,13 +29,19 @@ def assign_user_permissions(user):
 
 
 def assign_trainer_permissions(user):
+    NTAG_PERMISSIONS = [
+        'change_nfctag', 'view_nfctagdesign', 'view_nfctagscan'
+    ]
+
+    BOTANY_PERMISSIONS = [
+        'add_plant', 'change_plant', 'delete_plant', 'view_plant'
+    ]
+
     group, created = Group.objects.get_or_create(name='Trainers')
     if created:
         # Assign botany permissions for all trainers
-        from botany.constants import BOTANY_PERMISSIONS
         assign_group_permissions(group, BOTANY_PERMISSIONS)
 
         # Assign ntag permissions for all trainers
-        from ntags.constants import NTAG_PERMISSIONS
         assign_group_permissions(group, NTAG_PERMISSIONS)
     user.groups.add(group)

--- a/backend/ntags/constants.py
+++ b/backend/ntags/constants.py
@@ -16,4 +16,6 @@ NTAG_EEPROM_SIZES = {
 
 NTAG_PERMISSIONS = [
     'change_nfctag',
+    'view_nfctagdesign',
+    'view_nfctagscan'
 ]


### PR DESCRIPTION
This pull request refactors the permissions for trainers in the `assign_trainer_permissions` function. It separates the NTAG permissions and BOTANY permissions into separate lists and assigns them to the "Trainers" group. This improves the organization and readability of the code.