### PR TITLE
Refactor NFCTagAdminForm to include 'design' field

### DIFF
--- a/backend/ntags/forms.py
+++ b/backend/ntags/forms.py
@@ -19,7 +19,7 @@ class NFCTagAdminForm(WagtailAdminModelForm):
 
     class Meta:
         model = NFCTag
-        fields = ['label', 'content_type', 'item', 'active']
+        fields = ['label', 'content_type', 'item', 'active', 'design']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/backend/ntags/viewsets.py
+++ b/backend/ntags/viewsets.py
@@ -27,7 +27,7 @@ class NFCTagSnippetViewSet(SnippetViewSet):
 
     settings_panels = [
         FieldPanel("active"),
-        FieldPanel("design"),
+        FieldPanel("design")
     ]
     edit_handler = TabbedInterface(
         [


### PR DESCRIPTION
This pull request refactors the `NFCTagAdminForm` to include the 'design' field. The `fields` attribute in the `Meta` class of the form is updated to include the 'design' field. Additionally, the `NFCTagSnippetViewSet` is modified to include the 'design' field in the `settings_panels` list.