### PR TITLE
Refactor permissions for trainers and collections

### DIFF
--- a/backend/accounts/utils.py
+++ b/backend/accounts/utils.py
@@ -3,6 +3,23 @@ from django.contrib.auth.models import Group
 
 from base.utils import assign_group_permissions, assign_wagtail_group_permissions
 
+NTAG_PERMISSIONS = (
+    'change_nfctag', 'view_nfctagdesign', 'view_nfctagscan'
+)
+
+BOTANY_PERMISSIONS = (
+    'add_plant', 'change_plant', 'delete_plant', 'view_plant'
+)
+
+COLLECTION_PERMISSIONS = (
+    'add_image', 'change_image', 'choose_image',
+    'add_document', 'change_document', 'choose_document'
+)
+
+PAGE_PERMISSIONS = (
+    'add_page', 'publish_page'
+)
+
 
 @transaction.atomic
 def setup_new_trainer(user):
@@ -16,26 +33,18 @@ def setup_new_trainer(user):
 
 
 def assign_user_permissions(user):
-    from inventory.constants import PAGE_PERMISSIONS, COLLECTION_PERMISSIONS
 
-    group = user.get_group()
     assign_trainer_permissions(user)
+    group = user.get_group()
+
+    collection = user.get_collection()
+    assign_wagtail_group_permissions(group, collection, COLLECTION_PERMISSIONS)
 
     page = user.get_page()
     assign_wagtail_group_permissions(group, page, PAGE_PERMISSIONS)
 
-    collection = user.get_collection().collection
-    assign_wagtail_group_permissions(group, collection, COLLECTION_PERMISSIONS)
-
 
 def assign_trainer_permissions(user):
-    NTAG_PERMISSIONS = [
-        'change_nfctag', 'view_nfctagdesign', 'view_nfctagscan'
-    ]
-
-    BOTANY_PERMISSIONS = [
-        'add_plant', 'change_plant', 'delete_plant', 'view_plant'
-    ]
 
     group, created = Group.objects.get_or_create(name='Trainers')
     if created:

--- a/backend/botany/constants.py
+++ b/backend/botany/constants.py
@@ -1,3 +1,0 @@
-BOTANY_PERMISSIONS = [
-    'add_plant', 'change_plant', 'delete_plant', 'view_plant'
-]

--- a/backend/botany/viewsets.py
+++ b/backend/botany/viewsets.py
@@ -1,11 +1,6 @@
-import re
-from queryish.rest import APIModel
-from pygbif import species  # noqa
-
 from wagtail.admin.panels import TabbedInterface, FieldPanel, InlinePanel, ObjectList
 from wagtail.snippets.views.chooser import SnippetChooserViewSet
 from wagtail.snippets.views.snippets import SnippetViewSet
-from wagtail.admin.viewsets.chooser import ChooserViewSet
 
 from .models import UserPlant
 
@@ -62,38 +57,3 @@ class UserPlantViewSet(SnippetViewSet):
     def get_queryset(self, request):
         queryset = UserPlant.objects.filter(box__owner=request.user)
         return queryset
-
-
-class Species(APIModel):
-
-    def __str__(self):
-        return self.name
-
-    class Meta:
-        base_url = "https://pokeapi.co/api/v2/pokemon/"
-        detail_url = "https://pokeapi.co/api/v2/pokemon/%s/"
-        fields = ["id", "name"]
-        pagination_style = "offset-limit"
-        verbose_name_plural = "plant species"
-
-    @classmethod
-    def from_query_data(cls, data):
-        return cls(
-            id=int(re.match(r'https://pokeapi.co/api/v2/pokemon/(\d+)/', data['url']).group(1)),
-            name=data['name'],
-        )
-
-    @classmethod
-    def from_individual_data(cls, data):
-        return cls(
-            id=data['id'],
-            name=data['name'],
-        )
-
-
-class SpeciesChooserViewSet(ChooserViewSet):
-    model = Species
-    choose_one_text = "Choose a species"
-
-
-species_chooser_viewset = SpeciesChooserViewSet("species_chooser")  # noqa

--- a/backend/botany/wagtail_hooks.py
+++ b/backend/botany/wagtail_hooks.py
@@ -1,16 +1,12 @@
 from wagtail import hooks
 from wagtail.snippets.models import register_snippet
 
-from .viewsets import UserPlantViewSet, species_chooser_viewset
+from .viewsets import UserPlantViewSet
 
 
 @hooks.register("register_icons")
 def register_icons(icons):
     return icons + ['botany/icons/plant.svg']
 
-
-@hooks.register("register_admin_viewset")
-def register_species_chooser_viewset():
-    return species_chooser_viewset
 
 register_snippet(UserPlantViewSet)  # noqa

--- a/backend/botany/widgets.py
+++ b/backend/botany/widgets.py
@@ -1,4 +1,3 @@
-from .viewsets import UserPlantChooserViewSet, species_chooser_viewset
+from .viewsets import UserPlantChooserViewSet
 
-SpeciesChooserWidget = species_chooser_viewset.widget_class
 UserPlantChooserWidget = UserPlantChooserViewSet.widget_class # noqa F405

--- a/backend/inventory/constants.py
+++ b/backend/inventory/constants.py
@@ -1,8 +1,0 @@
-COLLECTION_PERMISSIONS = (
-    'add_image', 'change_image', 'choose_image',
-    'add_document', 'change_document', 'choose_document'
-)
-
-PAGE_PERMISSIONS = (
-    'add_page', 'publish_page'
-)


### PR DESCRIPTION
This pull request refactors the permissions for trainers and collections. It updates the permissions for trainers, including the NTAG permissions and the BOTANY permissions. It also assigns the Wagtail group permissions for collections, including the COLLECTION_PERMISSIONS and PAGE_PERMISSIONS. Additionally, it removes unused code related to species and species chooser viewsets.