### PR TITLE
Register NFCTagScan model with ReferenceIndex

### DIFF
--- a/backend/ntags/apps.py
+++ b/backend/ntags/apps.py
@@ -6,3 +6,8 @@ class NtagsConfig(AppConfig):
     name = 'ntags'
     verbose_name = _("NFC Tags")
     default_auto_field = 'django.db.models.BigAutoField'
+
+    def ready(self):
+        from wagtail.models.reference_index import ReferenceIndex
+        from .models import NFCTagScan
+        ReferenceIndex.register_model(NFCTagScan)  # noqa


### PR DESCRIPTION
Refactor the `apps.py` file to register the `NFCTagScan` model with the `ReferenceIndex`. This ensures that the `NFCTagScan` model is included in the reference index for easier searching and indexing.