### PR TITLE
Refactor NFC tag model and configuration

### DIFF
--- a/backend/digidex/settings/base.py
+++ b/backend/digidex/settings/base.py
@@ -331,6 +331,8 @@ WAGTAILSEARCH_BACKENDS = {
 # ------------------------------------------------------------------------
 # Wagtail-nfctags Configuration
 # ------------------------------------------------------------------------
+NFC_TAG_MODEL = 'ntags.NFCTag'
+
 NFC_TAGGABLE_MODELS = [
     'inventory.InventoryBoxPage',
     'botany.UserPlant'

--- a/backend/ntags/__init__.py
+++ b/backend/ntags/__init__.py
@@ -1,11 +1,42 @@
 import warnings
-from django.conf import settings
+
+
+def get_nfc_tag_model_string():
+    """
+    Returns the model string for the NFCTag model.
+    """
+    from django.conf import settings
+
+    tag_model = getattr(settings, 'NFC_TAG_MODEL', None)
+    if tag_model is None:
+        warnings.warn(
+            "NFC_TAG_MODEL is not set. Defaulting to 'nfc.NFCTag'.",
+            UserWarning
+        )
+        return 'ntags.NFCTag'
+    return tag_model
+
+
+def get_nfc_tag_model():
+    """
+    Returns the model class for the NFCTag model.
+    """
+    from django.apps import apps
+
+    model_string = get_nfc_tag_model_string()
+    try:
+        app_label, model_name = model_string.split('.')
+        return apps.get_model(app_label, model_name)
+    except (ValueError, LookupError):
+        raise ValueError(f"Invalid NFC_TAG_MODEL '{model_string}'")
 
 
 def get_nfc_taggable_model_strings():
     """
     Returns a list of model strings that are taggable by NFC tags.
     """
+    from django.conf import settings
+
     taggable_models = getattr(settings, 'NFC_TAGGABLE_MODELS', None)
     if taggable_models is None:
         warnings.warn(

--- a/backend/ntags/templates/nfctags/index.html
+++ b/backend/ntags/templates/nfctags/index.html
@@ -9,7 +9,7 @@
         <h2 class="heading">{{ heading }}</h2>
         <div class="block-button">
           {% for action, url in urls.items %}
-            {% if action == 'Page' or action == 'Home' %}
+            {% if action == 'Page' %}
               <a href="{{ url }}" class="button w-button">{{ action }}</a>
             {% elif action == 'Edit' %}
               <a href="{{ url }}" class="button-outline w-button">{{ action }}</a>


### PR DESCRIPTION
This pull request refactors the NFC tag model and configuration. It introduces a new function `get_nfc_tag_model_string()` that returns the model string for the NFCTag model. It also adds a new function `get_nfc_tag_model()` that returns the model class for the NFCTag model. The `BaseNFCTag` class is changed from inheriting from `ClusterableModel` to inheriting from `models.Model`. The `NFCTag` class is updated to include a `design` field and a `label` field. The `log_scan()` method is removed from the `BaseNFCTag` class and the `NFCTag` class. The `url` property and the `get_url()` method are updated to handle different actions and to return the appropriate URL. The `get_urls()` method is updated to return the URLs based on the user's group. The `link_nfc_tag()` view function is updated to use the `get_nfc_tag_model()` function to get the NFCTag model. It also includes error handling and logging for scanning NFC tags.