### PR TITLE
Fix broken image source in base.html

### DIFF
--- a/backend/digidex/templates/base.html
+++ b/backend/digidex/templates/base.html
@@ -37,7 +37,7 @@
   {% block body %}
     <body>
       <a href="/" class="brand-center w-nav-brand">
-        <img src="{% static 'base/images/logo/logo.svg}" alt="Digidex Logo" class="logo">
+        <img src="{% static 'base/images/logo/logo.svg' %}" alt="Digidex Logo" class="logo">
       </a>
       {% block content %}{% endblock content %}
     </body>


### PR DESCRIPTION
The image source in the base.html file was broken. This commit fixes the broken image source by correcting the syntax in the source attribute of the img tag.